### PR TITLE
Adhere to claude agent skills spec format

### DIFF
--- a/.claude/skills/solidity-guard/skills/vulnerability-scanner/SKILL.md
+++ b/.claude/skills/solidity-guard/skills/vulnerability-scanner/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: vulnerability-scanner
-description: |
-  Comprehensive Solidity contract security scanner detecting 104 vulnerability patterns
-  across reentrancy, access control, arithmetic, DeFi, proxy, and token categories.
-  Integrates Slither, Aderyn, and Mythril with manual analysis.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - Write
+description: Comprehensive Solidity contract security scanner detecting 104 vulnerability patterns across reentrancy, access control, arithmetic, DeFi, proxy, and token categories. Integrates Slither, Aderyn, and Mythril with manual analysis.
 ---
 
 # Solidity Vulnerability Scanner

--- a/.claude/skills/solidity-guard/skills/vulnerability-scanner/SKILL.md
+++ b/.claude/skills/solidity-guard/skills/vulnerability-scanner/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: solidity-vulnerability-scanner
+name: vulnerability-scanner
 description: |
   Comprehensive Solidity contract security scanner detecting 104 vulnerability patterns
   across reentrancy, access control, arithmetic, DeFi, proxy, and token categories.


### PR DESCRIPTION
PR to make this skill better pickable by claude code and similar

Skill.md must have a yaml frontmatter, where name is lowercase, and name needs to match the directory name.

This allows for correct extension of longer skills as when the file line count is over 500 we need to separate instructions to reference files. this is all from the claude docs.

Need this skills format compliance to list the skills in this repo on the Auditor Skill Registry ( https://forefy.com/skills )